### PR TITLE
error handling: refactored to create errors with appcode enum

### DIFF
--- a/AppStoreSearch/DataModel/DataModel.swift
+++ b/AppStoreSearch/DataModel/DataModel.swift
@@ -70,23 +70,23 @@ struct DataModel {
     }
     
     // pjh: used by AppStoreSearch service json -> coredata
-    static func queryForApps(term: String?, handle: @escaping([AppEntity], ApplicationErrorType) -> ()) -> (code:ApplicationErrorType, message:String) {
+    static func queryForApps(term: String?, handle: @escaping([AppEntity], AppCode) -> ()) -> (code:AppCode, message:String) {
         var message = "Search term is nil"
         guard let text = term else {
-            handle([], .searchTermIsNilErrorCode)
+            handle([], AppCode.searchTermIsNilErrorCode)
             return (code: .nilStringErrorCode, message: message)
         }
         
         guard text.isEmpty == false else {
             message = "Search term is empty"
-            handle([], .searchTermIsEmptyErrorCode)
-            return (code: .emptyStringErrorCode, message: message)
+            handle([], AppCode.searchTermIsEmptyErrorCode)
+            return (code: AppCode.emptyStringErrorCode, message: message)
         }
         
         guard let encoded = text.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
             message = "Search term could not be url encoded!"
-            handle([], .urlEncodingErrorCode)
-            return (code: .urlEncodingErrorCode, message: message)
+            handle([], AppCode.urlEncodingErrorCode)
+            return (code: AppCode.urlEncodingErrorCode, message: message)
         }
         
         logger.info("Query term is: \(encoded)")
@@ -100,7 +100,7 @@ struct DataModel {
             do {
                 let results = try await AppStoreService.queryStore(term: encoded, makeAppEntity: DataModel.makeAppEntityFromSource)
                 persistence.save()
-                handle(results.apps, .okayNoErrorCode)
+                handle(results.apps, AppCode.okayNoErrorCode)
                 print("appEntites count == \(results.apps.count)")
                 
             } catch {

--- a/AppStoreSearch/Service/AppStoreService.swift
+++ b/AppStoreSearch/Service/AppStoreService.swift
@@ -8,19 +8,7 @@
 import Foundation
 import os.log
 
-struct AppStoreServiceError: Error {
 
-    enum ErrorType {
-        case failedURLEncoding
-        case failedToDecodeHTTPResponse
-        case queryTimedOut
-    }
-    
-    let code = ApplicationErrorType.appStoreServiceErrorCode
-    let type: ErrorType
-    let text: String
-
-}
 
 
 struct AppStoreService {
@@ -28,7 +16,7 @@ struct AppStoreService {
     
     static var numberOfResultsPerQuery = 30 // 1 to 200 per API
     
-    static func queryStore(term: String, limit: Int = 0, makeAppEntity: ([String: Any]) -> AppEntity?) async throws -> (apps:[AppEntity], code: ApplicationErrorType) {
+    static func queryStore(term: String, limit: Int = 0, makeAppEntity: ([String: Any]) -> AppEntity?) async throws -> (apps:[AppEntity], code: AppCode) {
         var appEntities: [AppEntity] = []
         var limitToUse = limit
         if limit <= 0 {
@@ -37,7 +25,8 @@ struct AppStoreService {
         
         guard let url = URL(string: AppStoreService.buildURLString(term, limitToUse)) else {
             let message = "AppStoreService: failed to create URL"
-            throw AppStoreServiceError(type: .failedURLEncoding, text: message)
+            throw AppError.application(code: .appStoreServiceErrorCode, message: message)
+
         }
         
         Logger().info("AppStoreService: will use query: \(url.absoluteString)")
@@ -65,7 +54,7 @@ struct AppStoreService {
             
         } catch {
             let message = "AppStoreService: failed decode HTTP response"
-            throw AppStoreServiceError(type: .failedToDecodeHTTPResponse, text: message)
+            throw AppError.application(code: .appStoreServiceErrorCode, message: message)
         }
         
         

--- a/AppStoreSearch/Service/FileSystemService.swift
+++ b/AppStoreSearch/Service/FileSystemService.swift
@@ -16,7 +16,7 @@ struct FilesystemServiceError: Error {
         case failedToSaveJSONResponse
     }
     
-    let code = ApplicationErrorType.fileSystemServiceErrorCode
+    let code = AppCode.fileSystemServiceErrorCode
     let type: ErrorType
     let text: String
 
@@ -140,13 +140,13 @@ struct FileSystemService {
                                _ appId: Int64,
                                _ term: String,
                                _ index: Int,
-                               _ process: @escaping(Int64, String, Int, ApplicationErrorType) -> ()) {
+                               _ process: @escaping(Int64, String, Int, AppCode) -> ()) {
         screenshotQueue.async {
             let filepathURL = worker.screenshotPath(appId: appId, index: index + 1)
             if let data = rawData {
                 if let image = UIImage(data: data)?.jpegData(compressionQuality: 1) {
                     try? image.write(to: filepathURL)
-                    process(appId, term, index, .okayNoErrorCode)
+                    process(appId, term, index, AppCode.okayNoErrorCode)
                 }
             }
         }

--- a/AppStoreSearch/Service/MediaAssetsService.swift
+++ b/AppStoreSearch/Service/MediaAssetsService.swift
@@ -9,20 +9,7 @@ import Foundation
 import UIKit
 import os.log
 
-struct MediaAssetsServiceError: Error {
 
-    enum ErrorType {
-        case failedURLEncoding
-        case failedToDecodeHTTPResponse
-        case queryTimedOut
-        case failedToSaveScreenshotToFile
-    }
-    
-    let code = ApplicationErrorType.mediaAssetsServiceErrorCode
-    let type: ErrorType
-    let text: String
-
-}
 
 let serviceName = "MediaAssetsService"
 
@@ -31,11 +18,11 @@ struct MediaAssetsService {
     static func requestForAppIcon(url: String,
                                   appId: Int64,
                                   processAppIcon:(Int64, Data?) -> ()
-                                    ) async throws -> (Int64, ApplicationErrorType) {
+                                    ) async throws -> (Int64, AppCode) {
         
         guard let url = URL(string: url) else {
             let message = "MediaAssetsService: failed to create URL"
-            throw AppStoreServiceError(type: .failedURLEncoding, text: message)
+            throw AppError.application(code: AppCode.mediaAssetsServiceErrorCode, message: message)
         }
         
         Logger().info("MediaAssetsService: will use query: \(url.absoluteString)")
@@ -60,7 +47,7 @@ struct MediaAssetsService {
     static func requestForAllScreenshots(appId: Int64,
                                          urls: [URL],
                                          term: String,
-                                         process:@escaping (Int64, String, Int, ApplicationErrorType) -> ()) async throws -> ApplicationErrorType {
+                                         process:@escaping (Int64, String, Int, AppCode) -> ()) async throws -> AppCode {
         guard urls.count > 0 else { return .okayNoErrorCode }
         
         for (index, url) in urls.enumerated() {
@@ -82,8 +69,8 @@ struct MediaAssetsService {
                                      url: URL,
                                      term: String,
                                      index: Int,
-                                     process:@escaping (Int64, String, Int, ApplicationErrorType) -> ()
-                                    ) async throws -> ApplicationErrorType {
+                                     process:@escaping (Int64, String, Int, AppCode) -> ()
+                                    ) async throws -> AppCode {
 
         Logger().info("MediaAssetsService: will fetch screenshot: \(url.absoluteString)")
         // pjh: todo: check http response

--- a/AppStoreSearch/application/ApplicationErrorCodes.swift
+++ b/AppStoreSearch/application/ApplicationErrorCodes.swift
@@ -8,8 +8,19 @@
 import Foundation
 
 
-enum ApplicationErrorType {
-    
+enum AppError: Error {
+    // application errors
+    case application(code: AppCode, message: String)
+    // Network errors
+    case networking(code: AppCode, message: String, httpCode: Int)
+    // file IO
+    case fileSystem(code: AppCode, message: String)
+    // Media Assets
+    case mediaAssets(code: AppCode, message: String)
+}
+
+
+enum AppCode: Int {
     // application Errors
     case okayNoErrorCode
     case emptyStringErrorCode
@@ -30,3 +41,43 @@ enum ApplicationErrorType {
     
 }
 
+
+extension AppError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .application(code: let code, message: let message):
+            return "Error(application) >> message: \(message), code: \(code)"
+        case .networking(code: let code, message: let message, httpCode: let httpCode):
+            return "Error(networking) >> message: \(message), code: \(code), http code: \(httpCode)"
+        case .fileSystem(code: let code, message: let message):
+            return "Error(file system) >> message: \(message), code: \(code)"
+        case .mediaAssets(code: let code, message: let message):
+            return "Error(media assets) >> message: \(message), code: \(code)"
+        }
+    }
+}
+
+
+//protocol ApplicationError: Error {
+//    var code: ApplicationErrorCode { get }
+//    var text: String { get }
+//    var action: (()->())? { get }
+//
+//    func describe() -> String
+//
+//}
+
+//extension ApplicationError {
+//    /// pjh: default implementation, override as required
+//    func describe() -> String {
+//        let description = """
+//        -- Application Error(Default) --
+//        \tcategory: \(self.category)
+//        \tcode: \(self.code)
+//        \ttext: \(self.text)
+//        \taction to take: \(String(describing: self.action))
+//        """
+//
+//        return description
+//    }
+//}

--- a/AppStoreSearch/application/view/Screenshots/ScreeshotsGalleryViewController.swift
+++ b/AppStoreSearch/application/view/Screenshots/ScreeshotsGalleryViewController.swift
@@ -116,7 +116,7 @@ class ScreeshotsGalleryViewController: UIViewController {
     func processMediaRequest(_ appId: Int64,
                              _ term: String,
                              _ index: Int,
-                             _ applicationErrorType: ApplicationErrorType) -> () {
+                             _ ApplicationErrorCode: AppCode) -> () {
         DispatchQueue.main.async {
             print("Screenshot at index: \(index) is ready to display!!")
             if self.dataSource.count == 0 || (self.dataSource.count - 1) == index {


### PR DESCRIPTION
### Description
This `pr`  updates the error handling service for the app and can be considered a blueprint for error handling.  The `AppError` represents an error of a certain category, networking for example. You then further refine the error with an `AppCode` and a text message.

 