### PR TITLE
Setup of Networking reachability

### DIFF
--- a/AppStoreSearch.xcodeproj/project.pbxproj
+++ b/AppStoreSearch.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2BB7154527DBCD8D000F6DF1 /* ScreeshotsGalleryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB7154427DBCD8D000F6DF1 /* ScreeshotsGalleryViewController.swift */; };
 		2BB7154827DC066C000F6DF1 /* FilterOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB7154727DC066C000F6DF1 /* FilterOptionsViewController.swift */; };
 		2BB7154B27DD2897000F6DF1 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB7154A27DD2897000F6DF1 /* Extensions.swift */; };
+		2BCFF016281AF6A600384594 /* NetworkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCFF015281AF6A600384594 /* NetworkingService.swift */; };
 		2BD3426D27D7FD8B0042F33F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD3426C27D7FD8B0042F33F /* AppDelegate.swift */; };
 		2BD3426F27D7FD8B0042F33F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD3426E27D7FD8B0042F33F /* SceneDelegate.swift */; };
 		2BD3427127D7FD8B0042F33F /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD3427027D7FD8B0042F33F /* HomeViewController.swift */; };
@@ -60,6 +61,7 @@
 		2BB7154427DBCD8D000F6DF1 /* ScreeshotsGalleryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreeshotsGalleryViewController.swift; sourceTree = "<group>"; };
 		2BB7154727DC066C000F6DF1 /* FilterOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionsViewController.swift; sourceTree = "<group>"; };
 		2BB7154A27DD2897000F6DF1 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		2BCFF015281AF6A600384594 /* NetworkingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingService.swift; sourceTree = "<group>"; };
 		2BD3426927D7FD8B0042F33F /* AppStoreSearch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStoreSearch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2BD3426C27D7FD8B0042F33F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2BD3426E27D7FD8B0042F33F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				2BD342AD27D835200042F33F /* AppStoreService.swift */,
 				2BB7152A27D93C89000F6DF1 /* FileSystemService.swift */,
 				2BB7153827D9C10D000F6DF1 /* MediaAssetsService.swift */,
+				2BCFF015281AF6A600384594 /* NetworkingService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				2BB7153527D9672C000F6DF1 /* AppEntityTableViewCell.swift in Sources */,
 				2BD342A727D807130042F33F /* Entities.swift in Sources */,
 				2BB7154027DAF338000F6DF1 /* AppEntityDescriptionTableViewCell.swift in Sources */,
+				2BCFF016281AF6A600384594 /* NetworkingService.swift in Sources */,
 				2BD3427127D7FD8B0042F33F /* HomeViewController.swift in Sources */,
 				2BB7153927D9C10D000F6DF1 /* MediaAssetsService.swift in Sources */,
 				2BD342A227D801F10042F33F /* DataModel.swift in Sources */,

--- a/AppStoreSearch/Service/NetworkingService.swift
+++ b/AppStoreSearch/Service/NetworkingService.swift
@@ -1,0 +1,10 @@
+//
+//  NetworkingService.swift
+//  AppStoreSearch
+//
+//  Created by Peter hornsby on 4/28/22.
+//
+
+import Foundation
+import SystemConfiguration
+

--- a/AppStoreSearch/Service/NetworkingService.swift
+++ b/AppStoreSearch/Service/NetworkingService.swift
@@ -7,4 +7,97 @@
 
 import Foundation
 import SystemConfiguration
+import Network
+
+public enum ConnectionType: Int {
+    case wifi
+    case cellular
+    case any
+    
+    
+    var description: String {
+        switch self {
+        case.wifi:
+            return "wifi connection"
+        case .cellular:
+            return "celluar connection"
+        case .any:
+            return "any connection?"
+        }
+    }
+    
+}
+
+
+extension Notification.Name {
+    static let networkingReachabilityDidChange = Notification.Name(rawValue: "NetworkingReachabilityDidChangeNofication")
+}
+
+let service = NetworkService()
+
+
+class NetworkService {
+    public var isReachable = true
+    public var connectionType: ConnectionType?
+    private let monitor = NWPathMonitor()
+
+    public static func  startReachabilityMonitoring() {
+        service.startReachability()
+    }
+    
+    public static func  stopReachabilityMonitoring() {
+        service.stopReachability()
+    }
+    
+
+    func checkReachability(for connection: ConnectionType) -> Bool {
+        guard isReachable else { return false }
+        switch connection {
+        case.wifi:
+            return monitor.currentPath.usesInterfaceType(.wifi)
+        case .cellular:
+            return monitor.currentPath.usesInterfaceType(.cellular)
+        case .any:
+            return monitor.currentPath.usesInterfaceType(.wifi) ||
+            monitor.currentPath.usesInterfaceType(.cellular) ||
+            monitor.currentPath.usesInterfaceType(.other) ||
+            monitor.currentPath.usesInterfaceType(.wiredEthernet) ||
+            monitor.currentPath.usesInterfaceType(.loopback)
+        }
+    }
+    
+    func startReachability() {
+        func setConnectionType(_ path: NWPath) {
+            if path.usesInterfaceType(.wifi) {
+                self.connectionType = .wifi
+            } else if path.usesInterfaceType(.cellular) {
+                self.connectionType = .cellular
+            } else {
+                self.connectionType = .any
+            }
+        }
+        
+        monitor.pathUpdateHandler = { path in
+            if path.status == .satisfied {
+                self.isReachable = true
+                setConnectionType(path)
+            } else {
+                self.isReachable = false
+                self.connectionType = nil
+            }
+            
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .networkingReachabilityDidChange, object: nil)
+            }
+        }
+        
+        let queue = DispatchQueue.global(qos: .background)
+        monitor.start(queue: queue)
+    }
+    
+    func stopReachability() {
+        monitor.cancel()
+    }
+}
+
 

--- a/AppStoreSearch/application/delegates/AppDelegate.swift
+++ b/AppStoreSearch/application/delegates/AppDelegate.swift
@@ -14,6 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        NetworkService.startReachabilityMonitoring()
+        
         return true
     }
 

--- a/AppStoreSearch/application/view/Home/HomeViewController.swift
+++ b/AppStoreSearch/application/view/Home/HomeViewController.swift
@@ -178,7 +178,6 @@ class HomeViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
     
     func processMediaRequest(_ appId: Int64,  _ data: Data?, _ term: String) {
-        
         let updateUI = {
             DispatchQueue.main.async {
                 if let cells = self.appsListView.visibleCells as? [AppEntityTableViewCell] {
@@ -197,7 +196,6 @@ class HomeViewController: UIViewController, UITableViewDataSource, UITableViewDe
                                       appId: appId,
                                       term: term,
                                       completion: updateUI)
-
     }
     
     


### PR DESCRIPTION
### Description
This `pr` brings networking reachability functionality to the app. It is designed as a service that will send a notification on a change in  network reachability. It has been added to the app delegate. But no action is taken on posting of notification.